### PR TITLE
Rotate text displayed on surface of launchpad

### DIFF
--- a/examples/text_scroll.py
+++ b/examples/text_scroll.py
@@ -8,17 +8,10 @@ import sys
 import time
 
 
-def ascending_range():
-    counter = 1
-    while True:
-        yield counter
-        counter += 1
-
-
 def scroll_text(text, lp):
     try:
         while True:
-            for count in ascending_range():
+            for count in range(len(text) * lp.grid.width):
                 lp.grid.render(Text(text).shift_left(count))
                 time.sleep(.02)
     except KeyboardInterrupt:

--- a/lpminimk3/graphics/__init__.py
+++ b/lpminimk3/graphics/__init__.py
@@ -21,6 +21,9 @@ class Text(Renderable):
     def __str__(self):
         return self._text
 
+    def __len__(self):
+        return len(self._text)
+
     @Renderable.bits.getter
     def bits(self):
         return self._string.bits
@@ -43,4 +46,8 @@ class Text(Renderable):
     def shift_right(self, count=1, *, circular=True):
         count = 0 if not isinstance(count, int) or count < 0 else count
         self._string.shift_right(count=count, circular=circular)
+        return self
+
+    def rotate(self, angle):
+        self._string.rotate(angle)
         return self

--- a/lpminimk3/graphics/_utils.py
+++ b/lpminimk3/graphics/_utils.py
@@ -278,15 +278,17 @@ class CharacterTransform:
 
 
 class CharacterRenderer:
-    def __init__(self, character, matrix):
+    def __init__(self, character, matrix, *, angle=0):
         self._raw_bitmap = character.raw_bitmap
         self._matrix = matrix
         self._fg_color = character.fg_color
         self._bg_color = character.bg_color
+        self._angle = angle
 
     def render(self):
         colorspec_fragments = []
-        for led, bit in zip(self._matrix.led_range(), self._raw_bitmap):
+        for led, bit in zip(self._matrix.led_range(rotation=self._angle),
+                            self._raw_bitmap):
             bit_config = self._raw_bitmap.config[led.name]
             lighting_type = bit_config.lighting_type
             led_index = led.midi_value
@@ -347,6 +349,7 @@ class Character(Renderable):
                                         if transformed_bitmap_data
                                         else None)
         self._offset = Offset(*offset) if offset else Offset()
+        self._angle = 0
 
     def __repr__(self):
         return ("Character("
@@ -396,7 +399,9 @@ class Character(Renderable):
         return self._offset
 
     def render(self, matrix):
-        CharacterRenderer(self, matrix).render()
+        CharacterRenderer(self,
+                          matrix,
+                          angle=self._angle).render()
 
     def print(self):
         print(self.raw_bitmap)
@@ -415,6 +420,9 @@ class Character(Renderable):
                                                        count=count,
                                                        circular=circular)
 
+    def rotate(self, angle):
+        self._angle = angle
+
 
 class String(Renderable):
     def __init__(self, text, *, fg_color, bg_color=None):
@@ -428,6 +436,7 @@ class String(Renderable):
                                              fg_color,
                                              bg_color)
         self._characters = list(characters)
+        self._angle = 0
 
     def __repr__(self):
         return ("String("
@@ -458,7 +467,8 @@ class String(Renderable):
 
     def render(self, matrix):
         CharacterRenderer(self.character_to_render,
-                          matrix).render()
+                          matrix,
+                          angle=self._angle).render()
 
     def print(self):
         print(self.character_to_render.raw_bitmap)
@@ -499,6 +509,9 @@ class String(Renderable):
                     carry = new_character.carry
                     shifted_characters.append(new_character)
                 self._characters = shifted_characters
+
+    def rotate(self, angle):
+        self._angle = angle
 
     def _create_characters(self, text, dicts, fg_color, bg_color):
         characters = []

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -22,14 +22,26 @@ class TestGrid(unittest.TestCase):
     def test_max_x(self):
         self.lp.open()
         self.assertEqual(self.lp.grid.max_x,
-                         8,
+                         7,
                          'Max X mismatch.')
 
     def test_max_y(self):
         self.lp.open()
         self.assertEqual(self.lp.grid.max_y,
-                         8,
+                         7,
                          'Max Y mismatch.')
+
+    def test_width(self):
+        self.lp.open()
+        self.assertEqual(self.lp.grid.width,
+                         8,
+                         'Width mismatch.')
+
+    def test_height(self):
+        self.lp.open()
+        self.assertEqual(self.lp.grid.height,
+                         8,
+                         'Height mismatch.')
 
     def test_eq(self):
         self.lp.open()

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -22,14 +22,26 @@ class TestPanel(unittest.TestCase):
     def test_max_x(self):
         self.lp.open()
         self.assertEqual(self.lp.panel.max_x,
-                         9,
+                         8,
                          'Max X mismatch.')
 
     def test_max_y(self):
         self.lp.open()
         self.assertEqual(self.lp.panel.max_y,
-                         9,
+                         8,
                          'Max Y mismatch.')
+
+    def test_width(self):
+        self.lp.open()
+        self.assertEqual(self.lp.panel.width,
+                         9,
+                         'Width mismatch.')
+
+    def test_height(self):
+        self.lp.open()
+        self.assertEqual(self.lp.panel.height,
+                         9,
+                         'Height mismatch.')
 
     def test_eq(self):
         self.lp.open()


### PR DESCRIPTION
- Remove slow generator in text scroll example
- Change `Matrix.max_x` and `Matrix.max_y` to `Matrix.width` and
`Matrix.height` respectively, then repurpose `max_x` and `max_y` for
clarity
- Add `__len__()` to `Text`